### PR TITLE
优化矩形，其他调整

### DIFF
--- a/pvzclass/AsmFunctions.h
+++ b/pvzclass/AsmFunctions.h
@@ -1,4 +1,6 @@
 #include <Windows.h>
+#undef max
+#undef min
 
 #pragma region asm define
 

--- a/pvzclass/Classes/Rect.cpp
+++ b/pvzclass/Classes/Rect.cpp
@@ -1,5 +1,8 @@
 #include "../PVZ.h"
 
+using std::max;
+using std::min;
+
 int PVZ::GetXOverlap(const PVZ::Rect& rect1, const PVZ::Rect& rect2)
 {
 	int LeftR, RightR, RightL;
@@ -40,4 +43,17 @@ bool PVZ::Rect::IsCircleOverlap(const int X, const int Y, const int radius)
 
 		return(Xdist * Xdist + Ydist * Ydist <= radius * radius);
 	}
+}
+
+PVZ::Rect PVZ::Rect::Intersection(const Rect& rect) const
+{
+	int x1 = max(X, rect.X);
+	int x2 = min(X + Width, rect.X + rect.Width);
+	int y1 = max(Y, rect.Y);
+	int y2 = min(Y + rect.Height, rect.Y + rect.Height);
+
+	if (((x2 - x1) < 0) || ((y2 - y1) < 0))
+		return Rect(0, 0, 0, 0);
+	else
+		return Rect(x1, y1, x2 - x1, y2 - y1);
 }

--- a/pvzclass/Enums/MouseType.h
+++ b/pvzclass/Enums/MouseType.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 namespace MouseType
 {
 
@@ -14,7 +14,6 @@ namespace MouseType
 		Hammer,
 		Crosshair,
 		Watering,
-		GoldenWatering,
 		Fertilizer,
 		BugSpray,
 		Phonograph,
@@ -24,6 +23,7 @@ namespace MouseType
 		WheelBarrow,
 		TreeFood,
 	};
+	constexpr MouseType CobCannonTarget = Crosshair;
 
 	extern const char* ToString(MouseType mouset);
 

--- a/pvzclass/PVZ.h
+++ b/pvzclass/PVZ.h
@@ -120,9 +120,18 @@ namespace PVZ
 		int Y;
 		int Width;
 		int Height;
+
+		Rect(int X, int Y, int Width, int Height) : X(X), Y(Y), Width(Width), Height(Height) {}
+		Rect(const Rect& Rect) : X(Rect.X), Y(Rect.Y), Width(Rect.Width), Height(Rect.Height) {}
+		Rect() : X(0), Y(0), Width(0), Height(0) {}
+
 		// 判定坐标为 (X, Y)，半径为 radius 的圆与该矩阵是否有重叠部分。
 		// 相切会视为有重叠部分。
 		bool IsCircleOverlap(const int X, const int Y, const int radius);
+		/// @brief 获取与另一矩形重叠的部分。
+		/// @param rect 另一矩形
+		/// @return 两矩形的重叠部分。若无交叉部分，返回空矩形。
+		Rect Intersection(const Rect& rect) const;
 	};
 	// 取得两个矩形横向重叠部分的长度。
 	// 若横向无重叠部分，返回两矩形横向间距的相反数。


### PR DESCRIPTION
- 全局：
  - `cstdlib` 的 `max` `min` 宏已被取消定义。若要使用，请自行定义或使用 `std` 版本。
- 基础类：
  - 为 `Rect` 添加构造函数。
  - 为 `Rect` 添加新成员函数，用于求两矩形重叠部分。
- 枚举：
  - Fix #11 