### PR TITLE
若干优化和修复

### DIFF
--- a/pvzclass/Events/DLLEvent.h
+++ b/pvzclass/Events/DLLEvent.h
@@ -300,7 +300,7 @@ protected:
 	static constexpr std::array<uint8_t, 19> compiled_special_bytes =
 	{
 		TEST_AL_AL,
-		JS(19),
+		JS(15),
 		POPAD,
 		JE(6),
 

--- a/pvzclass/Events/PlantDamageZombieEvent.hpp
+++ b/pvzclass/Events/PlantDamageZombieEvent.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "DLLEvent.h"
 
 namespace PVZEvent
@@ -64,7 +64,7 @@ namespace PVZEvent
 					MOV_EUX_PTR_ADDR(REG_EBP, tmp),
 
 					MOV_EUX_PTR_EVX_ADD_V(REG_EAX, REG_EBP, 0x0C),
-					MOV_PTR_ESP_ADD_V_EUX(REG_EAX, 0),
+					MOV_PTR_ESP_ADD_V_EUX(REG_EAX, 4),
 
 					MOV_EUX_PTR_EVX_ADD_V(REG_ESI, REG_EBP, 0),
 					MOV_EUX_PTR_EVX_ADD_V(REG_EDI, REG_EBP, 4),
@@ -115,7 +115,7 @@ namespace PVZEvent
 					MOV_EUX_PTR_ADDR(REG_EBP, tmp),
 
 					MOV_EUX_PTR_EVX_ADD_V(REG_EAX, REG_EBP, 0x0C),
-					MOV_PTR_ESP_ADD_V_EUX(REG_EAX, 0),
+					MOV_PTR_ESP_ADD_V_EUX(REG_EAX, 4),
 
 					MOV_EUX_PTR_EVX_ADD_V(REG_ESI, REG_EBP, 0),
 					MOV_EUX_PTR_EVX_ADD_V(REG_EDI, REG_EBP, 4),
@@ -166,7 +166,7 @@ namespace PVZEvent
 					MOV_EUX_PTR_ADDR(REG_EBP, tmp),
 
 					MOV_EUX_PTR_EVX_ADD_V(REG_EAX, REG_EBP, 0x0C),
-					MOV_PTR_ESP_ADD_V_EUX(REG_EAX, 0),
+					MOV_PTR_ESP_ADD_V_EUX(REG_EAX, 4),
 
 					MOV_EUX_PTR_EVX_ADD_V(REG_ESI, REG_EBP, 0),
 					MOV_EUX_PTR_EVX_ADD_V(REG_EDI, REG_EBP, 4),
@@ -217,7 +217,7 @@ namespace PVZEvent
 					MOV_EUX_PTR_ADDR(REG_EBP, tmp),
 
 					MOV_EUX_PTR_EVX_ADD_V(REG_EAX, REG_EBP, 0x0C),
-					MOV_PTR_ESP_ADD_V_EUX(REG_EAX, 0),
+					MOV_PTR_ESP_ADD_V_EUX(REG_EAX, 4),
 
 					MOV_EUX_PTR_EVX_ADD_V(REG_ESI, REG_EBP, 0),
 					MOV_EUX_PTR_EVX_ADD_V(REG_EDI, REG_EBP, 4),

--- a/pvzclass/Events/ProjectileImageEvent.hpp
+++ b/pvzclass/Events/ProjectileImageEvent.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "DLLEvent.h"
 
 namespace PVZEvent
@@ -25,12 +25,17 @@ namespace PVZEvent
 			ImgRow(const char* str) : IntDLLEventTemplate() { Init(str); };
 			ImgRow(int address) : IntDLLEventTemplate() { Init(address); };
 		};
-		class Img : public IntDLLEventTemplate<0x46E6C7, 5, 0, 0,
-			0, MEM_ESP_ADD(0x2C), false, CONST_VAL(PROJECTILE_IMAGE), REG_ESI>
+		class Img : public DLLEventTemplate<0x46E6C3, 9, CONST_VAL(PROJECTILE_IMAGE), REG_ESI>
 		{
 		public:
-			Img(const char* str) : IntDLLEventTemplate() { Init(str); };
-			Img(int address) : IntDLLEventTemplate() { Init(address); };
+			Img(const char* str) : DLLEventTemplate() { Init(str); };
+			Img(int address) : DLLEventTemplate() { Init(address); };
+		protected:
+			virtual void InitExtra(AsmBuilder& builder)
+			{
+				builder.cmp_reg_imm(REG_EAX, 0).jl_rel(4);
+				builder.mov_mem_esp_add_imm8_reg(0x2C, REG_EAX);
+			}
 		};
 		ImgRow* img_row;
 		Img* image;

--- a/pvzclass/Extensions.h
+++ b/pvzclass/Extensions.h
@@ -293,3 +293,10 @@ inline void SetGoldMagnetLimit(int num)
 	PVZ::Memory::WriteMemory<int>(0x46549C, num);
 	PVZ::Memory::WriteMemory<int>(0x4626BF, num);
 }
+
+/// @brief 禁用 IZ 下僵尸在一定条件下对防御植物造成额外啃咬伤害的效果
+/// @param b 是否开启此功能
+inline void DisableIZExtraEatDamage(BOOLEAN b = true)
+{
+	MEMMOD_BYTE(0x52FD0B, JUMP, JZ);
+}

--- a/pvzclass/Extensions.h
+++ b/pvzclass/Extensions.h
@@ -300,3 +300,14 @@ inline void DisableIZExtraEatDamage(BOOLEAN b = true)
 {
 	MEMMOD_BYTE(0x52FD0B, JUMP, JZ);
 }
+
+/// @brief 禁用巨大坚果的影子偏移、眨眼动作、大小缩放的特殊设定。
+/// @param b 是否开启此功能
+inline void DisableGiantWallNutScale(BOOLEAN b = true)
+{
+	MEMMOD_BYTE(0x465916, JUMP, JNE);
+	MEMMOD_BYTE(0x487D4C, JUMP, JNE);
+	MEMMOD_BYTE(0x466211, JUMP, JNE);
+	MEMMOD_BYTE(0x4639E8, JUMP, JNE);
+	MEMMOD_BYTE(0x463F7F, 0x80, 0x84);
+}


### PR DESCRIPTION
- 事件：
  - 修复 `ThreeStateEventTemplate` 偏移量不正确的漏洞。
  - 修复 `ProjectileImageEvent` 有时会造成子弹图片翻转的漏洞。
  - 修复 `PlantDamageZombieEvent` 覆盖伤害不正确的漏洞。
- 扩展：
  - 添加了两个扩展函数。