### PR TITLE
修复漏洞

### DIFF
--- a/pvzclass/Classes/Board.cpp
+++ b/pvzclass/Classes/Board.cpp
@@ -359,7 +359,7 @@ void PVZ::Board::RemoveNotExistGameObjects()
 {
 	PVZ::Memory::Execute(AsmBuilder()
 		.mov_reg_imm(REG_ESI, BaseAddress)
-		.call_reg(0x41BAD0)
+		.invoke(0x41BAD0)
 		.ret()
 	);
 }

--- a/pvzclass/include/Events/PlantDamageZombieEvent.hpp
+++ b/pvzclass/include/Events/PlantDamageZombieEvent.hpp
@@ -263,7 +263,9 @@ namespace PVZEvent
 					MOV_PTR_EUX_ADD_V(REG_EDX, 0x10, PLANTDAMAGETYPE_AOE),
 
 					PUSH_EDX,
+					PUSH_EDX,
 					INVOKE(address),
+					ADD_ESP(4),
 					POP_EUX(REG_EDX),
 					MOV_PTR_ADDR_EUX(REG_EDX, tmp),
 					POPAD,


### PR DESCRIPTION
- 修复 `PlantDamageZombieEvent` 的 `Part5` 会导致崩溃的漏洞。
- fix #85 