### PR TITLE
部分代码优化

### DIFF
--- a/pvzclass/Classes/Zombie.cpp
+++ b/pvzclass/Classes/Zombie.cpp
@@ -192,13 +192,13 @@ void PVZ::Zombie::SetBodyHp(int hp, int maxhp)
 PVZ::Animation PVZ::Zombie::GetAnimation()
 {
 	int ID = Memory::ReadMemory<int>(BaseAddress + 0x118);
-	return PVZ::Animation(ID_INDEX(ID));
+	return (ID_RANK(ID) == 0) ? INVALID_BASEADDRESS : ID_INDEX(ID);
 }
 
 PVZ::Animation PVZ::Zombie::GetSpecialHeadAnimation()
 {
 	int ID = Memory::ReadMemory<int>(BaseAddress + 0x144);
-	return PVZ::Animation(ID_INDEX(ID));
+	return (ID_RANK(ID) == 0) ? INVALID_BASEADDRESS : ID_INDEX(ID);
 }
 
 void PVZ::Zombie::SetSpecialHeadAnimation(PVZ::Animation anim)

--- a/pvzclass/include/Flags.hpp
+++ b/pvzclass/include/Flags.hpp
@@ -1,4 +1,4 @@
-﻿namespace PVZ
+namespace PVZ
 {
 	#pragma region DamageRangeFlags
 
@@ -6,27 +6,27 @@
 	typedef unsigned char DamageRangeFlags;
 
 	/// @brief 是否位于地面上（或水面上）。
-	const DamageRangeFlags DRF_GROUND = (1 << 0);
+	constexpr DamageRangeFlags DRF_GROUND = (1 << 0);
 	/// @brief 是否飞行。
-	const DamageRangeFlags DRF_FLYING = (1 << 1);
+	constexpr DamageRangeFlags DRF_FLYING = (1 << 1);
 	/// @brief 是否潜水。
-	const DamageRangeFlags DRF_SUBMERGED = (1 << 2);
+	constexpr DamageRangeFlags DRF_SUBMERGED = (1 << 2);
 	/// @brief 内测版中用于判断是否为僵尸狗。正式版 PVZ 中被废弃。
-	const DamageRangeFlags DRF_DOG = (1 << 3);
+	constexpr DamageRangeFlags DRF_DOG = (1 << 3);
 	/// @brief 是否正在落地（或出土）。
-	const DamageRangeFlags DRF_OFF_GROUND = (1 << 4);
+	constexpr DamageRangeFlags DRF_OFF_GROUND = (1 << 4);
 	/// @brief 是否考虑已被击杀的僵尸。
-	const DamageRangeFlags DRF_DYING = (1 << 5);
+	constexpr DamageRangeFlags DRF_DYING = (1 << 5);
 	/// @brief 是否位于地下。
-	const DamageRangeFlags DRF_UNDERGROUND = (1 << 6);
+	constexpr DamageRangeFlags DRF_UNDERGROUND = (1 << 6);
 	/// @brief 是否被魅惑。
-	const DamageRangeFlags DRF_HYPNOTIZED = (1 << 7);
+	constexpr DamageRangeFlags DRF_HYPNOTIZED = (1 << 7);
 
 	/// @brief 全体未被魅惑的僵尸。
-	const DamageRangeFlags DRF_ALL = DRF_GROUND | DRF_FLYING
+	constexpr DamageRangeFlags DRF_ALL = DRF_GROUND | DRF_FLYING
 		| DRF_SUBMERGED | DRF_DOG | DRF_OFF_GROUND | DRF_DYING | DRF_UNDERGROUND;
 	/// @brief 全体被魅惑的僵尸。
-	const DamageRangeFlags DRF_ALL_HYPNOTIZED = DRF_HYPNOTIZED | DRF_ALL;
+	constexpr DamageRangeFlags DRF_ALL_HYPNOTIZED = DRF_HYPNOTIZED | DRF_ALL;
 
 	#pragma endregion
 

--- a/pvzclass/src/Creators.cpp
+++ b/pvzclass/src/Creators.cpp
@@ -382,8 +382,8 @@ PVZ::Rake Creator::CreateRake(byte row, byte column)
 		.ret()
 	);
 
-	rake.X = board.GridToXPixel(row, column);
-	rake.Y = board.GridToYPixel(row, column);
+	rake.X = static_cast<float>(board.GridToXPixel(row, column));
+	rake.Y = static_cast<float>(board.GridToYPixel(row, column));
 
 	auto model = Creator::CreateReanimation(AnimationType::Rake, rake.X + 20.0f, rake.Y, 0);
 	model.LoopType = PVZEnum::REANIM_PLAY_ONCE_AND_HOLD;


### PR DESCRIPTION
- 修复 `Zombie::GetAnimation()` 和 `Zombie::GetSpecialHeadAnimation()` 不能返回无效对象的漏洞。
- `DamageRangeFlags` 常量现在使用 `constexpr`。
- 消除 `Creator::CreateRake()` 的警告。