### PR TITLE
修复 pvzdll debug 构建配置问题

### DIFF
--- a/pvzdll/pvzdll.vcxproj
+++ b/pvzdll/pvzdll.vcxproj
@@ -61,6 +61,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
       <AdditionalDependencies>pvzclass.lib;dbghelp.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">


### PR DESCRIPTION
修复 pvzdll 构建配置不含 $(OutDir) 的漏洞。