### PR TITLE
新增 PVZString，其他调整

### DIFF
--- a/.github/workflows/protect-Stable.yml
+++ b/.github/workflows/protect-Stable.yml
@@ -1,30 +1,19 @@
-name: PRBlock
+name: PRBlock-Stable
 
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-    branches: [ "Stable" ]
+    branches: 
+      - Stable
 
 jobs:
   close-pr:
     runs-on: ubuntu-latest
 
     steps:        
-    - id: close-operation
+    - id: block-operation
       uses: actions/github-script@v7
       with:
         script: |
-          const targetBranch = '${{ steps.check-branch.outputs.target_branch }}';
-          await github.rest.issues.createComment({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: context.issue.number,
-            body: `🚫 **PR 自动关闭通知**\n\n这个 PR 的目标分支是 **${targetBranch}**，该分支用于维护稳定版 PVZClass，不允许合并 PR。\n\n请将目标分支更改为 Refurbishment 等受保护分支。`
-          });
-          
-          await github.rest.pulls.update({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            pull_number: context.issue.number,
-            state: 'closed'
-          });
+          echo "这个 PR 的目标分支是 Stable，该分支用于维护稳定版 PVZClass，不允许合并 PR。\n\n如果你尝试修复 2.x 版本的漏洞，请以 Stable-2.x 为目标分支重新开启 PR。"
+          exit 1

--- a/pvzclass/AsmBuilder.hpp
+++ b/pvzclass/AsmBuilder.hpp
@@ -740,6 +740,13 @@ public:
 		return *this;
 	}
 
+	AsmBuilder& cmp_mem_RAI32_imm32(uint8_t reg, uint32_t imm, uint32_t val)
+	{
+		if (reg > 7)
+			throw std::invalid_argument("Invalid register for CMP");
+		return this->add_byte(0x81).add_byte(0xB8 + reg).add_dword(imm).add_dword(val);
+	}
+
 	AsmBuilder& test_al_al()
 	{
 		return this->add_byte(0x84).add_byte(0xC0);

--- a/pvzclass/PVZ.cpp
+++ b/pvzclass/PVZ.cpp
@@ -163,6 +163,23 @@ PVZ::PVZString PVZ::PVZString::Make(const char* str)
 	return toAddress;
 }
 
+void PVZ::PVZString::Free()
+{
+	PVZ::Memory::Execute(AsmBuilder()
+		.mov_reg_imm(REG_EBX, this->BaseAddress)
+		.cmp_mem_RAI32_imm32(REG_EBX, 0x18, 16)
+		.jb_rel(20)
+
+		.mov_reg_mem_reg_add_imm(REG_EAX, REG_EBX, 4)
+		.push_reg(REG_EAX)
+		.invoke(0x61C19A)
+		.add_reg_imm(REG_ESP, 4)
+
+		.ret()
+	);
+	PVZ::Memory::FreeMemory(this->BaseAddress);
+}
+
 byte __asm_KillGameSelector[] =
 {
 	MOV_ESI(0),

--- a/pvzclass/PVZ.cpp
+++ b/pvzclass/PVZ.cpp
@@ -140,6 +140,29 @@ PVZ::Mouse PVZ::GetMouse()
 	return Mouse(Memory::ReadPointer(0x6A9EC0, 0x320));
 }
 
+uint8_t __asm__MakeString[]
+{
+	PUSHDWORD(0),
+	MOV_ECX(0),
+	INVOKE(0x404450),
+	RET
+};
+
+PVZ::PVZString PVZ::PVZString::Make(const char* str) 
+{
+	uint32_t len = strlen(str);
+	uint32_t fromAddress = PVZ::Memory::AllocMemory(0, len + 1);
+	PVZ::Memory::WriteArray<const char>(fromAddress, str, len + 1);
+	uint32_t toAddress = PVZ::Memory::AllocMemory(0, 0x1C);
+
+	SETARG(__asm__MakeString, 1) = fromAddress;
+	SETARG(__asm__MakeString, 6) = toAddress;
+	PVZ::Memory::Execute(STRING(__asm__MakeString));
+
+	PVZ::Memory::FreeMemory(fromAddress);
+	return toAddress;
+}
+
 byte __asm_KillGameSelector[] =
 {
 	MOV_ESI(0),

--- a/pvzclass/PVZ.h
+++ b/pvzclass/PVZ.h
@@ -77,13 +77,13 @@ namespace PVZ
 	{
 	protected:
 		/// @brief 对应对象的基地址
-		int BaseAddress;
+		uint32_t BaseAddress;
 	public:
 		BaseClass() : BaseAddress(INVALID_BASEADDRESS) {};
-		BaseClass(int address) : BaseAddress(address) {};
+		BaseClass(uint32_t address) : BaseAddress(address) {};
 		/// @brief 返回基址
 		/// @return 基址
-		int GetBaseAddress() const
+		uint32_t GetBaseAddress() const
 		{ return(this->BaseAddress); }
 		/// @brief 对应的对象是否已经失效，或者构造不良。
 		/// @return 是否已经失效或构造不良。

--- a/pvzclass/PVZ.h
+++ b/pvzclass/PVZ.h
@@ -129,6 +129,21 @@ namespace PVZ
 		READONLY_PROPERTY(PVZVersion::PVZVersion,	__get_GameVersion)	GameVersion;
 	};
 
+	/// @brief 字符串类，用于对应 PVZ 内部的 std::string
+	class PVZString : public BaseClass
+	{
+	public:
+		PVZString(DWORD address) : BaseClass(address) {};
+		/// @brief 在 PVZ 主程序中创建字符串
+		/// @note 以此法创建的字符串需要使用 Free() 销毁，否则会造成内存泄露。
+		/// @return 创建的字符串
+		/// @author Moon404
+		static PVZString Make(const char* str);
+		/// @brief 释放该字符串在 PVZ 占用的内存空间
+		/// @attention 只有通过 Make 创建的字符串才应该使用该函数销毁。
+		void Free();
+	};
+
 	/// @brief 游戏程序主类（原 LawnApp）。
 	class PVZApp : public BaseClass
 	{

--- a/pvzdll/pvzdll.vcxproj
+++ b/pvzdll/pvzdll.vcxproj
@@ -61,6 +61,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
       <AdditionalDependencies>pvzclass.lib;dbghelp.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">


### PR DESCRIPTION
- 现在 `BaseClass` 及其派生类的 `BaseAddress` 均为 `uint32_t` 类型。
- 添加了 `PVZString`，用于取代原本的 `PString`。
  - 其成员函数用于构造和销毁 `PVZString`。
- #93 的全部改动内容。