### PR TITLE
将 GetByIndex 从默认构造函数中独立出来

### DIFF
--- a/pvzclass/Classes/Animation.cpp
+++ b/pvzclass/Classes/Animation.cpp
@@ -1,12 +1,9 @@
 #include <cstring>
 #include "../PVZ.h"
 
-PVZ::Animation::Animation(int idoraddress)
+PVZ::Animation PVZ::Animation::GetByIndex(uint32_t index)
 {
-	if (idoraddress > 1024)
-		BaseAddress = idoraddress;
-	else
-		BaseAddress = Memory::ReadPointer(0x6A9EC0, 0x820, 8, 0) + idoraddress * 0xA0;
+	return PVZ::Animation(Memory::ReadPointer(0x6A9EC0, 0x820, 8, 0) + index * 0xA0);
 }
 
 void PVZ::Animation::UnLock(int animprop)

--- a/pvzclass/Classes/Attachment.cpp
+++ b/pvzclass/Classes/Attachment.cpp
@@ -1,11 +1,8 @@
-﻿#include "../PVZ.h"
+#include "../PVZ.h"
 
-PVZ::Attachment::Attachment(int idoraddress)
+PVZ::Attachment PVZ::Attachment::GetByIndex(uint32_t index)
 {
-	if (idoraddress > 1024)
-		BaseAddress = idoraddress;
-	else
-		BaseAddress = Memory::ReadPointer(0x6A9EC0, 0x820, 0xC, 0) + idoraddress * 0x30C;
+	return PVZ::Attachment(Memory::ReadPointer(0x6A9EC0, 0x820, 0xC, 0) + index * 0x30C);
 }
 
 PVZ::Animation PVZ::Attachment::GetAnimation()

--- a/pvzclass/Classes/Coin.cpp
+++ b/pvzclass/Classes/Coin.cpp
@@ -2,12 +2,9 @@
 
 DWORD PVZ::Coin::MemSize = 0x0D8;
 
-PVZ::Coin::Coin(int indexoraddress)
+PVZ::Coin PVZ::Coin::GetByIndex(uint32_t index)
 {
-	if (indexoraddress > 1024)
-		BaseAddress = indexoraddress;
-	else
-		BaseAddress = Memory::ReadMemory<int>(PVZBASEADDRESS + 0xE4) + indexoraddress * MemSize;
+    return PVZ::Coin(Memory::ReadMemory<uint32_t>(PVZBASEADDRESS + 0x0E4) + index * MemSize);
 }
 
 void PVZ::Coin::GetCollision(PVZ::Rect* collbox)

--- a/pvzclass/Classes/GameObject.hpp
+++ b/pvzclass/Classes/GameObject.hpp
@@ -40,6 +40,7 @@ namespace PVZ
 	{
 	protected:
 		GameObject() : BaseClass(0) {};
+		GameObject(uint32_t address) : BaseClass(address) {};
 	public:
 		/// @brief 获取 GameObject 所在的 PVZApp
 		PVZApp GetLawnApp()
@@ -72,10 +73,14 @@ namespace PVZ
 	{
 	public:
 		/// @attention 从 3.0 起，该函数将不再具有按编号构造的功能。
-		Zombie(int indexoraddress);
+		Zombie(uint32_t address) : GameObject(address) {};
 		/// @brief 僵尸的内存占用字节数。\n
 		///		若派生类需要对应扩指针的对象，请在派生类中修改此数值。
 		static DWORD MemSize;
+		/// @brief 获取指定编号的对象
+		/// @param index 编号
+		/// @note 不保证以此法获得的对象未被移除
+		static PVZ::Zombie GetByIndex(uint32_t index);
 		/// @brief 调整该类在 PVZ 中对象的大小。
 		/// @note 请在派生类中调用这个函数。
 		/// @note 该函数会自动调整 MemSize。
@@ -366,7 +371,11 @@ namespace PVZ
 		///		若派生类需要对应扩指针的对象，请在派生类中修改此数值。
 		static DWORD MemSize;
 		/// @attention 从 3.0 起，该函数将不再具有按编号构造的功能。
-		Plant(int indexoraddress);
+		Plant(uint32_t address) : GameObject(address) {};
+		/// @brief 获取指定编号的对象
+		/// @param index 编号
+		/// @note 不保证以此法获得的对象未被移除
+		static PVZ::Plant GetByIndex(uint32_t index);
 		/// @brief 调整该类在 PVZ 中对象的大小。
 		/// @note 请在派生类中调用这个函数。
 		/// @note 该函数会自动调整 MemSize。
@@ -506,7 +515,11 @@ namespace PVZ
 		///		若派生类需要对应扩指针的对象，请在派生类中修改此数值。
 		static DWORD MemSize;
 		/// @attention 从 3.0 起，该函数将不再具有按编号构造的功能。
-		Coin(int indexoraddress);
+		Coin(uint32_t address) : GameObject(address) {};
+		/// @brief 获取指定编号的对象
+		/// @param index 编号
+		/// @note 不保证以此法获得的对象未被移除
+		static PVZ::Coin GetByIndex(uint32_t index);
 		INT_READONLY_PROPERTY(ImageXVariation, __get_ImageXVariation, 8);
 		INT_READONLY_PROPERTY(ImageYVariation, __get_ImageYVariation, 0xC);
 		void GetCollision(Rect* collbox);
@@ -553,7 +566,11 @@ namespace PVZ
 		///		若派生类需要对应扩指针的对象，请在派生类中修改此数值。
 		static DWORD MemSize;
 		/// @attention 从 3.0 起，该函数将不再具有按编号构造的功能。
-		Projectile(int indexoraddress);
+		Projectile(uint32_t address) : GameObject(address) {};
+		/// @brief 获取指定编号的对象
+		/// @param index 编号
+		/// @note 不保证以此法获得的对象未被移除
+		static PVZ::Projectile GetByIndex(uint32_t index);
 		/// @brief 实际 X 坐标
 		T_PROPERTY(FLOAT, X, __get_X, __set_X, 0x30);
 		/// @brief 子弹本体的 Y 坐标

--- a/pvzclass/Classes/GameObject.hpp
+++ b/pvzclass/Classes/GameObject.hpp
@@ -73,7 +73,7 @@ namespace PVZ
 	public:
 		/// @attention 从 3.0 起，该函数将不再具有按编号构造的功能。
 		Zombie(int indexoraddress);
-		/// @brief 植物的内存占用字节数。\n
+		/// @brief 僵尸的内存占用字节数。\n
 		///		若派生类需要对应扩指针的对象，请在派生类中修改此数值。
 		static DWORD MemSize;
 		/// @brief 调整该类在 PVZ 中对象的大小。

--- a/pvzclass/Classes/GameObject.hpp
+++ b/pvzclass/Classes/GameObject.hpp
@@ -71,6 +71,7 @@ namespace PVZ
 	class Zombie : public GameObject
 	{
 	public:
+		/// @attention 从 3.0 起，该函数将不再具有按编号构造的功能。
 		Zombie(int indexoraddress);
 		/// @brief 植物的内存占用字节数。\n
 		///		若派生类需要对应扩指针的对象，请在派生类中修改此数值。
@@ -364,6 +365,7 @@ namespace PVZ
 		/// @brief 植物的内存占用字节数。\n
 		///		若派生类需要对应扩指针的对象，请在派生类中修改此数值。
 		static DWORD MemSize;
+		/// @attention 从 3.0 起，该函数将不再具有按编号构造的功能。
 		Plant(int indexoraddress);
 		/// @brief 调整该类在 PVZ 中对象的大小。
 		/// @note 请在派生类中调用这个函数。
@@ -503,6 +505,7 @@ namespace PVZ
 		/// @brief 掉落物的内存占用字节数。\n
 		///		若派生类需要对应扩指针的对象，请在派生类中修改此数值。
 		static DWORD MemSize;
+		/// @attention 从 3.0 起，该函数将不再具有按编号构造的功能。
 		Coin(int indexoraddress);
 		INT_READONLY_PROPERTY(ImageXVariation, __get_ImageXVariation, 8);
 		INT_READONLY_PROPERTY(ImageYVariation, __get_ImageYVariation, 0xC);
@@ -549,6 +552,7 @@ namespace PVZ
 		/// @brief 子弹的内存占用字节数。\n
 		///		若派生类需要对应扩指针的对象，请在派生类中修改此数值。
 		static DWORD MemSize;
+		/// @attention 从 3.0 起，该函数将不再具有按编号构造的功能。
 		Projectile(int indexoraddress);
 		/// @brief 实际 X 坐标
 		T_PROPERTY(FLOAT, X, __get_X, __set_X, 0x30);

--- a/pvzclass/Classes/Griditem.cpp
+++ b/pvzclass/Classes/Griditem.cpp
@@ -4,12 +4,9 @@
 
 DWORD PVZ::Griditem::MemSize = 0x0EC;
 
-PVZ::Griditem::Griditem(int indexoraddress)
+PVZ::Griditem PVZ::Griditem::GetByIndex(uint32_t index)
 {
-	if (indexoraddress > 1024)
-		BaseAddress = indexoraddress;
-	else
-		BaseAddress = Memory::ReadMemory<int>(PVZBASEADDRESS + 0x11C) + indexoraddress * MemSize;
+	return PVZ::Griditem(Memory::ReadMemory<uint32_t>(PVZ::GetBoard().GetBaseAddress() + 0x11C) + index * MemSize);
 }
 
 PVZ::Board PVZ::Griditem::GetBoard()

--- a/pvzclass/Classes/Griditem.hpp
+++ b/pvzclass/Classes/Griditem.hpp
@@ -14,7 +14,11 @@ namespace PVZ
 		/// @brief 默认的场地物件类型，派生类需要定义同名常量，用于在 Board::GetAllGriditems() 中定向获取场地物件。
 		static const GriditemType::GriditemType ItemType = GriditemType::None;
 		/// @attention 从 3.0 起，该函数将不再具有按编号构造的功能。
-		Griditem(int indexoraddress);
+		Griditem(uint32_t address) : BaseClass(address) {};
+		/// @brief 获取指定编号的对象
+		/// @param index 编号
+		/// @note 不保证以此法获得的对象未被移除
+		static PVZ::Griditem GetByIndex(uint32_t index);
 		Griditem(std::nullptr_t addr) : BaseClass(0) {};
 		/// @brief 场地物件所在的 PVZApp
 		T_PROPERTY(PVZApp, App, __get_App, __set_App, 0);
@@ -59,7 +63,7 @@ namespace PVZ
 	{
 	public:
 		static const GriditemType::GriditemType ItemType = GriditemType::Grave;
-		Grave(int indexoraddress) : Griditem(indexoraddress) {};
+		Grave(uint32_t address) : Griditem(address) {};
 		Grave(Griditem griditem) : Griditem(griditem.GetBaseAddress()) {};
 		INT_PROPERTY(AppearedValue, __get_AppearedValue, __set_AppearedValue, 0x18);
 	};
@@ -68,7 +72,7 @@ namespace PVZ
 	{
 	public:
 		static const GriditemType::GriditemType ItemType = GriditemType::Crater;
-		Crater(int indexoraddress) :Griditem(indexoraddress) {};
+		Crater(uint32_t address) :Griditem(address) {};
 		Crater(Griditem griditem) : Griditem(griditem.GetBaseAddress()) {};
 		/// @brief 消失倒计时
 		INT_PROPERTY(DisappearCountdown, __get_DisappearCountdown, __set_DisappearCountdown, 0x18);
@@ -78,7 +82,7 @@ namespace PVZ
 	{
 	public:
 		static const GriditemType::GriditemType ItemType = GriditemType::AquariumBrain;
-		AquariumBrain(int indexoraddress) :Griditem(indexoraddress) {};
+		AquariumBrain(uint32_t address) :Griditem(address) {};
 		AquariumBrain(Griditem griditem) : Griditem(griditem.GetBaseAddress()) {};
 	};
 	/// @brief 禅境花园的蜗牛
@@ -86,7 +90,7 @@ namespace PVZ
 	{
 	public:
 		static const GriditemType::GriditemType ItemType = GriditemType::Snail;
-		Snail(int indexoraddress) :Griditem(indexoraddress) {};
+		Snail(uint32_t address) :Griditem(address) {};
 		Snail(Griditem griditem) : Griditem(griditem.GetBaseAddress()) {};
 		/// @brief 目标 X 坐标
 		T_PROPERTY(FLOAT, TargetX, __get_TargetX, __set_TargetX, 0x2C);
@@ -98,7 +102,7 @@ namespace PVZ
 	{
 	public:
 		static const GriditemType::GriditemType ItemType = GriditemType::Vase;
-		Vase(int indexoraddress) :Griditem(indexoraddress) {};
+		Vase(uint32_t address) :Griditem(address) {};
 		Vase(Griditem griditem) : Griditem(griditem.GetBaseAddress()) {};
 		/// @brief 罐子外观。本质是场地物件的状态。
 		T_PROPERTY(VaseSkin::VaseSkin, Skin, __get_Skin, __set_Skin, 0xC);
@@ -122,7 +126,7 @@ namespace PVZ
 	{
 	public:
 		static const GriditemType::GriditemType ItemType = GriditemType::Rake;
-		Rake(int indexoraddress) : Griditem(indexoraddress) {};
+		Rake(uint32_t address) : Griditem(address) {};
 		Rake(Griditem griditem) : Griditem(griditem.GetBaseAddress()) {};
 	};
 	/// @brief IZ 模式的脑子
@@ -130,7 +134,7 @@ namespace PVZ
 	{
 	public:
 		static const GriditemType::GriditemType ItemType = GriditemType::IZBrain;
-		IZBrain(int indexoraddress) :Griditem(indexoraddress) {};
+		IZBrain(uint32_t address) :Griditem(address) {};
 		IZBrain(Griditem griditem) : Griditem(griditem.GetBaseAddress()) {};
 		/// @brief 脑子剩余生命值
 		INT_PROPERTY(Hp, __get_Hp, __set_Hp, 0x18);
@@ -141,7 +145,7 @@ namespace PVZ
 	class Portal :public PVZ::Griditem
 	{
 	public:
-		Portal(int indexoraddress) :Griditem(indexoraddress) {};
+		Portal(uint32_t address) :Griditem(address) {};
 		Portal(Griditem griditem) : Griditem(griditem.GetBaseAddress()) {};
 		/// @brief 关闭此传送门
 		void Close();
@@ -173,7 +177,7 @@ namespace PVZ
 	{
 	public:
 		static const GriditemType::GriditemType ItemType = GriditemType::PortalBlue;
-		CirclePortal(int indexoraddress) : Portal(indexoraddress) {};
+		CirclePortal(uint32_t address) : Portal(address) {};
 		CirclePortal(Griditem griditem) : Portal(griditem.GetBaseAddress()) {};
 	};
 	/// @brief 矩形传送门，颜色为黄框
@@ -181,7 +185,7 @@ namespace PVZ
 	{
 	public:
 		static const GriditemType::GriditemType ItemType = GriditemType::PortalYellow;
-		SquarePortal(int indexoraddress) : Portal(indexoraddress) {};
+		SquarePortal(uint32_t address) : Portal(address) {};
 		SquarePortal(Griditem griditem) : Portal(griditem.GetBaseAddress()) {};
 	};
 }

--- a/pvzclass/Classes/Griditem.hpp
+++ b/pvzclass/Classes/Griditem.hpp
@@ -13,6 +13,7 @@ namespace PVZ
 		static DWORD MemSize;
 		/// @brief 默认的场地物件类型，派生类需要定义同名常量，用于在 Board::GetAllGriditems() 中定向获取场地物件。
 		static const GriditemType::GriditemType ItemType = GriditemType::None;
+		/// @attention 从 3.0 起，该函数将不再具有按编号构造的功能。
 		Griditem(int indexoraddress);
 		Griditem(std::nullptr_t addr) : BaseClass(0) {};
 		/// @brief 场地物件所在的 PVZApp

--- a/pvzclass/Classes/LawnMower.hpp
+++ b/pvzclass/Classes/LawnMower.hpp
@@ -14,6 +14,7 @@ namespace PVZ
 		/// @brief 除草机的内存占用字节数。\n
 		///		若派生类需要对应扩指针的对象，请在派生类中修改此数值。
 		static DWORD MemSize;
+		/// @attention 从 3.0 起，该函数将不再具有按编号构造的功能。
 		LawnMower(int indexoraddress);
 		/// @brief 所在的 PVZApp
 		T_PROPERTY(PVZApp, App, __get_App, __set_App, 0);

--- a/pvzclass/Classes/LawnMower.hpp
+++ b/pvzclass/Classes/LawnMower.hpp
@@ -15,7 +15,11 @@ namespace PVZ
 		///		若派生类需要对应扩指针的对象，请在派生类中修改此数值。
 		static DWORD MemSize;
 		/// @attention 从 3.0 起，该函数将不再具有按编号构造的功能。
-		LawnMower(int indexoraddress);
+		LawnMower(uint32_t address) : BaseClass(address) {};
+		/// @brief 获取指定编号的对象
+		/// @param index 编号
+		/// @note 不保证以此法获得的对象未被移除
+		static LawnMower GetByIndex(uint32_t index);
 		/// @brief 所在的 PVZApp
 		T_PROPERTY(PVZApp, App, __get_App, __set_App, 0);
 		/// @brief 所在的 Board

--- a/pvzclass/Classes/Lawnmover.cpp
+++ b/pvzclass/Classes/Lawnmover.cpp
@@ -2,12 +2,9 @@
 
 DWORD PVZ::Lawnmover::MemSize = 0x48;
 
-PVZ::LawnMower::LawnMower(int indexoraddress)
+PVZ::LawnMower PVZ::LawnMower::GetByIndex(uint32_t index)
 {
-	if (indexoraddress > 1024)
-		BaseAddress = indexoraddress;
-	else
-		BaseAddress = Memory::ReadMemory<int>(PVZBASEADDRESS + 0x100) + indexoraddress * MemSize;
+    return LawnMower(Memory::ReadMemory<int>(PVZ::GetBoard().GetBaseAddress() + 0x100) + index * MemSize);
 }
 
 PVZ::Animation PVZ::LawnMower::GetAnimation()

--- a/pvzclass/Classes/Plant.cpp
+++ b/pvzclass/Classes/Plant.cpp
@@ -2,12 +2,9 @@
 
 DWORD PVZ::Plant::MemSize = 0x14C;
 
-PVZ::Plant::Plant(int indexoraddress)
+PVZ::Plant PVZ::Plant::GetByIndex(uint32_t index)
 {
-	if (indexoraddress > 1024)
-		BaseAddress = indexoraddress;
-	else
-		BaseAddress = Memory::ReadMemory<int>(PVZBASEADDRESS + 0xAC) + indexoraddress * MemSize;
+	return PVZ::Plant(Memory::ReadMemory<uint32_t>(PVZBASEADDRESS + 0x0AC) + index * MemSize);
 }
 
 void PVZ::Plant::SetMemSize(int NewSize = 0x14C, int NewCount = 1024)

--- a/pvzclass/Classes/Projectile.cpp
+++ b/pvzclass/Classes/Projectile.cpp
@@ -4,7 +4,7 @@ DWORD PVZ::Projectile::MemSize = 0x94;
 
 PVZ::Projectile PVZ::Projectile::GetByIndex(uint32_t index)
 {
-	return PVZ::Projectile(Memory::ReadMemory<int>(PVZBASEADDRESS + 0x0C8) + indexoraddress * MemSize);
+	return PVZ::Projectile(Memory::ReadMemory<int>(PVZBASEADDRESS + 0x0C8) + index * MemSize);
 }
 
 void PVZ::Projectile::CheckForCollision()

--- a/pvzclass/Classes/Projectile.cpp
+++ b/pvzclass/Classes/Projectile.cpp
@@ -2,12 +2,9 @@
 
 DWORD PVZ::Projectile::MemSize = 0x94;
 
-PVZ::Projectile::Projectile(int indexoraddress)
+PVZ::Projectile PVZ::Projectile::GetByIndex(uint32_t index)
 {
-	if (indexoraddress > 65535)
-		BaseAddress = indexoraddress;
-	else
-		BaseAddress = Memory::ReadMemory<int>(PVZBASEADDRESS + 0xC8) + indexoraddress * MemSize;
+	return PVZ::Projectile(Memory::ReadMemory<int>(PVZBASEADDRESS + 0x0C8) + indexoraddress * MemSize);
 }
 
 byte __asm__OnFire[]

--- a/pvzclass/Classes/TodParticleSystem.cpp
+++ b/pvzclass/Classes/TodParticleSystem.cpp
@@ -1,11 +1,8 @@
 #include "TodParticleSystem.hpp"
 
-PVZ::TodParticleSystem::TodParticleSystem(DWORD indexoraddress) : BaseClass(0)
+PVZ::TodParticleSystem PVZ::TodParticleSystem::GetByIndex(uint32_t index)
 {
-	if (indexoraddress < 65536)
-		BaseAddress = Memory::ReadPointer(0x6A9EC0, 0x820, 0, 0) + indexoraddress * 0x2C;
-	else
-		BaseAddress = indexoraddress;
+	return PVZ::TodParticleSystem(Memory::ReadPointer(0x6A9EC0, 0x820, 0, 0) + index * 0x2C);
 }
 
 void PVZ::TodParticleSystem::Die()

--- a/pvzclass/Classes/TodParticleSystem.hpp
+++ b/pvzclass/Classes/TodParticleSystem.hpp
@@ -8,6 +8,7 @@ namespace PVZ
 	class TodParticleSystem : public BaseClass
 	{
 	public:
+		/// @attention 从 3.0 起，该函数将不再具有按编号构造的功能。
 		TodParticleSystem(DWORD indexoraddress);
 		/// @brief 是否已被移除。
 		T_PROPERTY(BOOLEAN, Dead, __get_Dead, __set_Dead, 0x1C);

--- a/pvzclass/Classes/TodParticleSystem.hpp
+++ b/pvzclass/Classes/TodParticleSystem.hpp
@@ -9,7 +9,11 @@ namespace PVZ
 	{
 	public:
 		/// @attention 从 3.0 起，该函数将不再具有按编号构造的功能。
-		TodParticleSystem(DWORD indexoraddress);
+		TodParticleSystem(uint32_t address) : BaseClass(address) {};
+		/// @brief 获取指定编号的对象
+		/// @param index 编号
+		/// @note 不保证以此法获得的对象未被移除
+		static TodParticleSystem GetByIndex(uint32_t index);
 		/// @brief 是否已被移除。
 		T_PROPERTY(BOOLEAN, Dead, __get_Dead, __set_Dead, 0x1C);
 		T_PROPERTY(DWORD, Id, __get_Id, __set_Id, 0x28);

--- a/pvzclass/Classes/TrackInstance.cpp
+++ b/pvzclass/Classes/TrackInstance.cpp
@@ -1,11 +1,8 @@
 #include "../PVZ.h"
 
-PVZ::TrackInstance::TrackInstance(int idoraddress) : BaseClass(0)
+PVZ::TrackInstance PVZ::TrackInstance::GetByIndex(uint32_t index)
 {
-	if (idoraddress >= 1024)
-		this->BaseAddress = idoraddress;
-	else
-		this->BaseAddress = Memory::ReadPointer(0x6A9EC0, 0x820, 0xC, 0) + idoraddress * 0x30C;
+	return TrackInstance(Memory::ReadPointer(0x6A9EC0, 0x820, 0xC, 0) + index * 0x30C);
 }
 
 PVZ::AttachmentID PVZ::TrackInstance::GetAttachmentID()

--- a/pvzclass/Classes/Zombie.cpp
+++ b/pvzclass/Classes/Zombie.cpp
@@ -4,12 +4,9 @@ using std::max;
 
 DWORD PVZ::Zombie::MemSize = 0x15C;
 
-PVZ::Zombie::Zombie(int indexoraddress)
+PVZ::Zombie PVZ::Zombie::GetByIndex(uint32_t index)
 {
-	if (indexoraddress > 65535)
-		BaseAddress = indexoraddress;
-	else
-		BaseAddress = Memory::ReadMemory<int>(PVZBASEADDRESS + 0x90) + indexoraddress * MemSize;
+	return PVZ::Zombie(Memory::ReadMemory<uint32_t>(PVZBASEADDRESS + 0x90) + index * MemSize);
 }
 
 void PVZ::Zombie::SetMemSize(int NewSize, int NewCount)

--- a/pvzclass/PVZ.h
+++ b/pvzclass/PVZ.h
@@ -297,6 +297,7 @@ namespace PVZ
 	class Animation : public BaseClass
 	{
 	public:
+		/// @attention 从 3.0 起，该函数将不再具有按编号构造的功能。
 		Animation(int idoraddress);
 		//support muiti-animprop(AP_XXXXXX)
 		static void UnLock(int animprop);
@@ -398,6 +399,7 @@ namespace PVZ
 	class Attachment : public BaseClass
 	{
 	public:
+		/// @attention 从 3.0 起，该函数将不再具有按编号构造的功能。
 		Attachment(int idoraddress);
 		// TODO: check whether this function works properly.
 		PVZ::Animation GetAnimation();
@@ -411,6 +413,7 @@ namespace PVZ
 	class TrackInstance : public BaseClass
 	{
 	public:
+		/// @attention 从 3.0 起，该函数将不再具有按编号构造的功能。
 		TrackInstance(int idoraddress);
 		AttachmentID GetAttachmentID();
 		Attachment GetAttachment();

--- a/pvzclass/PVZ.h
+++ b/pvzclass/PVZ.h
@@ -92,6 +92,21 @@ namespace PVZ
 		{ return(this->BaseAddress != INVALID_BASEADDRESS && this->BaseAddress != 0); }
 	};
 
+	template<typename T>
+	T GetByID(int id)
+	{
+		if (id)
+		{
+			T tmp = T::GetByIndex(ID_INDEX(id));
+			if (tmp.Id != id)
+				return T(nullptr);
+			else
+				return tmp;
+		}
+		else
+			return T(nullptr);
+	}
+
 	class Rect
 	{
 	public:

--- a/pvzclass/PVZ.h
+++ b/pvzclass/PVZ.h
@@ -313,7 +313,11 @@ namespace PVZ
 	{
 	public:
 		/// @attention 从 3.0 起，该函数将不再具有按编号构造的功能。
-		Animation(int idoraddress);
+		Animation(uint32_t address) : BaseClass(address) {};
+		/// @brief 获取指定编号的对象
+		/// @param index 编号
+		/// @note 不保证以此法获得的对象未被移除
+		static Animation GetByIndex(uint32_t index);
 		//support muiti-animprop(AP_XXXXXX)
 		static void UnLock(int animprop);
 		static void Lock();
@@ -415,7 +419,11 @@ namespace PVZ
 	{
 	public:
 		/// @attention 从 3.0 起，该函数将不再具有按编号构造的功能。
-		Attachment(int idoraddress);
+		Attachment(uint32_t address) : BaseClass(address) {};
+		/// @brief 获取指定编号的对象
+		/// @param index 编号
+		/// @note 不保证以此法获得的对象未被移除
+		static Attachment GetByIndex(uint32_t index);
 		// TODO: check whether this function works properly.
 		PVZ::Animation GetAnimation();
 		INT_READONLY_PROPERTY(Id, __get_Id, 0x308);
@@ -429,7 +437,11 @@ namespace PVZ
 	{
 	public:
 		/// @attention 从 3.0 起，该函数将不再具有按编号构造的功能。
-		TrackInstance(int idoraddress);
+		TrackInstance(uint32_t address) : BaseClass(address) {};
+		/// @brief 获取指定编号的对象
+		/// @param index 编号
+		/// @note 不保证以此法获得的对象未被移除
+		static TrackInstance GetByIndex(uint32_t index);
 		AttachmentID GetAttachmentID();
 		Attachment GetAttachment();
 	};


### PR DESCRIPTION
这个 PR 所属的所有内容在完工时的效果如题。

构造函数同时具有按地址构造和按编号构造，会为空指针构造带来很大麻烦。

除此之外还有可能造成意料之外的构造，带来其他问题。

使用 `nullptr_t` 约束构造类型，虽然本体改动小，但其他函数也需要额外写一段对接代码，颇为麻烦。

最简洁的方案只剩“分离按编号构造和按地址构造”一个、

该 PR 分三个阶段：
1. 创建 `GetByIndex()` 和 `GetByID`，用于按编号构造和按识别 ID 构造；
2. 令 pvzclass 库内的函数对这些改动兼容；
3. 撤销构造函数按编号构造的能力。

目前 PR 中的内容只是发布了警告，并没有进行实质改动。

该 PR 计划在完成第一阶段后合并。