### PR TITLE
ZombieTakeDmgEvent拓展

### DIFF
--- a/pvzclass/Classes/GameObject.hpp
+++ b/pvzclass/Classes/GameObject.hpp
@@ -344,7 +344,7 @@ namespace PVZ
 		Rect GetActualAttackRect();
 		/// @brief 获取僵尸的实际受击范围。
 		/// @return 僵尸的实际受击范围
-		Rect GetActualRect();
+		Rect GetZombieRect();
 		/// @brief 根据僵尸当前的运动，估算僵尸在time后大概的受击中心x
 		float ZombieTargetLeadX(float time);
 
@@ -488,6 +488,8 @@ namespace PVZ
 		void UpdateBowling();
 		/// @brief 坚果类植物（坚果、高坚果）的动态函数，根据植物当前血量更新其形态相应的覆写贴图。
 		void AnimateNuts();
+		/// @brief 获取植物的实际受击矩形
+		Rect GetPlantRect();
 		class MagnetItem
 		{
 			int BaseAddress;
@@ -622,6 +624,8 @@ namespace PVZ
 		/// @brief 子弹造成溅射伤害
 		/// @param zombie 主目标僵尸，可以为空
 		void DoSplashDamage(PVZ::Zombie zombie);
+		/// @brief 获取子弹的实际受击矩形
+		Rect GetProjectileRect();
 		/// @brief 子弹过火，转化为火球
 		void OnFire();
 		/// @brief 移除该子弹。

--- a/pvzclass/Classes/Plant.cpp
+++ b/pvzclass/Classes/Plant.cpp
@@ -236,6 +236,22 @@ void PVZ::Plant::AnimateNuts()
 	);
 }
 
+PVZ::Rect PVZ::Plant::GetPlantRect()
+{
+	PVZ::Memory::Execute(AsmBuilder()
+		.mov_reg_imm(REG_EAX, PVZ::Memory::Variable)
+		.mov_reg_imm(REG_ECX, this->GetBaseAddress())
+		.invoke(0x467EF0)
+		.ret()
+	);
+	auto rect = Rect{};
+	rect.X = PVZ::Memory::ReadMemory<int>(PVZ::Memory::Variable + 0);
+	rect.Y = PVZ::Memory::ReadMemory<int>(PVZ::Memory::Variable + 4);
+	rect.Width = PVZ::Memory::ReadMemory<int>(PVZ::Memory::Variable + 8);
+	rect.Height = PVZ::Memory::ReadMemory<int>(PVZ::Memory::Variable + 12);
+	return rect;
+}
+
 PVZ::Plant::MagnetItem::MagnetItem(int address)
 {
 	BaseAddress = address;

--- a/pvzclass/Classes/Projectile.cpp
+++ b/pvzclass/Classes/Projectile.cpp
@@ -48,7 +48,21 @@ void PVZ::Projectile::DoSplashDamage(PVZ::Zombie zombie)
 		.ret()
 	);
 }
-
+PVZ::Rect PVZ::Projectile::GetProjectileRect()
+{
+	PVZ::Memory::Execute(AsmBuilder()
+		.mov_reg_imm(REG_ECX, PVZ::Memory::Variable)
+		.mov_reg_imm(REG_ESI, this->GetBaseAddress())
+		.invoke(0x46EBC0)
+		.ret()
+	);
+	auto rect = Rect{};
+	rect.X = PVZ::Memory::ReadMemory<int>(PVZ::Memory::Variable + 0);
+	rect.Y = PVZ::Memory::ReadMemory<int>(PVZ::Memory::Variable + 4);
+	rect.Width = PVZ::Memory::ReadMemory<int>(PVZ::Memory::Variable + 8);
+	rect.Height = PVZ::Memory::ReadMemory<int>(PVZ::Memory::Variable + 12);
+	return rect;
+}
 byte __asm__OnFire[]
 {
 	MOV_ECX(0),

--- a/pvzclass/Classes/Zombie.cpp
+++ b/pvzclass/Classes/Zombie.cpp
@@ -695,7 +695,7 @@ PVZ::Rect PVZ::Zombie::GetActualAttackRect()
 	return tmp;
 }
 
-PVZ::Rect PVZ::Zombie::GetActualRect()
+PVZ::Rect PVZ::Zombie::GetZombieRect()
 {
 	PVZ::Memory::Execute(AsmBuilder()
 		.mov_reg_imm(REG_EDI, PVZ::Memory::Variable)

--- a/pvzclass/PVZ.h
+++ b/pvzclass/PVZ.h
@@ -205,6 +205,8 @@ namespace PVZ
 		T_PROPERTY(BOOLEAN,						Shutdown,			__get_Shutdown,				__set_Shutdown,				0x341);
 		/// @brief 窗口句柄
 		T_PROPERTY(HWND,						HWnd,				__get_HWnd,					__set_HWnd,					0x350);
+		/// @brief DEBUG按键是否开启
+		T_PROPERTY(bool,						mDebugKeysEnabled,  __get_mDebugKeysEnabled,	__set_mDebugKeysEnabled,	0x5AC);
 		/// @brief 当前模式类型
 		T_PROPERTY(PVZLevel::PVZLevel,			LevelId,			__get_LevelId,				__set_LevelId,				0x7F8);
 		/// @brief 游戏状态

--- a/pvzclass/include/Events/ZombieTakeDmgEvent.h
+++ b/pvzclass/include/Events/ZombieTakeDmgEvent.h
@@ -33,7 +33,19 @@ public:
 	{
 		hookAddress = 0x5317C0;
 		rawlen = 7;
-		BYTE code[] = { PUSH_PTR_ESP_ADD_V(36), MOV_PTR_ADDR_EAX(PVZ::Memory::Variable), PUSHDWORD(PVZ::Memory::Variable), PUSH_ESI, INVOKE(address), MOV_EAX_PTR(PVZ::Memory::Variable), ADD_ESP(12), MOV_PTR_ESP_ADD_V_EUX(0, 36)};
+		BYTE code[] = {
+			PUSH_PTR_ESP_ADD_V(36),
+			MOV_PTR_ADDR_EAX(PVZ::Memory::Variable),
+			PUSHDWORD(PVZ::Memory::Variable),
+			PUSH_ESI,
+			INVOKE(address),
+			ADD_ESP(12),
+			MOV_PTR_ESP_ADD_V_EUX(0, 36),
+			POPAD,
+			MOV_EAX_PTR(PVZ::Memory::Variable),
+			0x51, 0x8B, 0x4E, 0x28, 0x83, 0xF9, 0x10,// <-origincode here
+			PUSHDWORD(0x5317C7),
+			RET};
 		start(STRING(code));
 	}
 };

--- a/pvzclass/include/Events/ZombieTakeDmgEvent.h
+++ b/pvzclass/include/Events/ZombieTakeDmgEvent.h
@@ -35,14 +35,14 @@ public:
 		rawlen = 7;
 		BYTE code[] = {
 			PUSH_PTR_ESP_ADD_V(36),
-			MOV_PTR_ADDR_EAX(PVZ::Memory::Variable),
-			PUSHDWORD(PVZ::Memory::Variable),
+			MOV_PTR_ADDR_EAX(PVZ::Memory::Variable + 400),
+			PUSHDWORD(PVZ::Memory::Variable + 400),
 			PUSH_ESI,
 			INVOKE(address),
 			ADD_ESP(12),
 			MOV_PTR_ESP_ADD_V_EUX(0, 36),
 			POPAD,
-			MOV_EAX_PTR(PVZ::Memory::Variable),
+			MOV_EAX_PTR(PVZ::Memory::Variable + 400),
 			0x51, 0x8B, 0x4E, 0x28, 0x83, 0xF9, 0x10,// <-origincode here
 			PUSHDWORD(0x5317C7),
 			RET

--- a/pvzclass/include/Events/ZombieTakeDmgEvent.h
+++ b/pvzclass/include/Events/ZombieTakeDmgEvent.h
@@ -45,7 +45,8 @@ public:
 			MOV_EAX_PTR(PVZ::Memory::Variable),
 			0x51, 0x8B, 0x4E, 0x28, 0x83, 0xF9, 0x10,// <-origincode here
 			PUSHDWORD(0x5317C7),
-			RET};
+			RET
+		};
 		start(STRING(code));
 	}
 };

--- a/pvzclass/include/Events/ZombieTakeDmgEvent.h
+++ b/pvzclass/include/Events/ZombieTakeDmgEvent.h
@@ -22,7 +22,7 @@ public:
 };
 
 /// @brief 僵尸受伤事件
-/// @param 触发事件的僵尸，伤害类型，伤害数值
+/// @param 触发事件的僵尸，伤害类型的引用，伤害数值
 /// @return 更新后的伤害值
 class ZombieTakeDmgEvent : public DLLEvent
 {
@@ -33,7 +33,7 @@ public:
 	{
 		hookAddress = 0x5317C0;
 		rawlen = 7;
-		BYTE code[] = { PUSH_PTR_ESP_ADD_V(36), PUSH_EAX, PUSH_ESI, INVOKE(address), ADD_ESP(12), MOV_PTR_ESP_ADD_V_EUX(0, 36) };
+		BYTE code[] = { PUSH_PTR_ESP_ADD_V(36), MOV_PTR_ADDR_EAX(PVZ::Memory::Variable), PUSHDWORD(PVZ::Memory::Variable), PUSH_ESI, INVOKE(address), MOV_EAX_PTR(PVZ::Memory::Variable), ADD_ESP(12), MOV_PTR_ESP_ADD_V_EUX(0, 36)};
 		start(STRING(code));
 	}
 };


### PR DESCRIPTION
- 现在ZombieTakeDmgEvent为回调函数传入类型为`PVZ::DamageFlags`的引用(指针), 用以支持修改DamageFlag
- 新增PVZApp的mDebugKeysEnabled成员
- 重命名和实现了Plant，Zombie，Projectile类获取实际矩形的方法