### PR TITLE
GetByID() 最后适配，常量优化

### DIFF
--- a/pvzclass/AsmFunctions.h
+++ b/pvzclass/AsmFunctions.h
@@ -75,14 +75,14 @@ typedef uint8_t byte;
 
 #pragma region asm extra
 
-#define REG_EAX 0
-#define REG_ECX 1
-#define REG_EDX 2
-#define REG_EBX 3
-#define REG_ESP 4
-#define REG_EBP 5
-#define REG_ESI 6
-#define REG_EDI 7
+inline constexpr auto REG_EAX = 0;
+inline constexpr auto REG_ECX = 1;
+inline constexpr auto REG_EDX = 2;
+inline constexpr auto REG_EBX = 3;
+inline constexpr auto REG_ESP = 4;
+inline constexpr auto REG_EBP = 5;
+inline constexpr auto REG_ESI = 6;
+inline constexpr auto REG_EDI = 7;
 
 #define JNO(b) 0x71,b
 #define JB(b) 0x72,b

--- a/pvzclass/Classes/GameObject.hpp
+++ b/pvzclass/Classes/GameObject.hpp
@@ -490,12 +490,13 @@ namespace PVZ
 		/// @brief 立即更新一次
 		void Update();
 		/// @deprecated
-		PVZ::Projectile Shoot(int targetid = -1);
+		[[deprecated]] PVZ::Projectile Shoot(int targetid = -1);
 		/// @brief 立刻发射子弹
 		/// @param motiontype 子弹移动类型
 		/// @param targetid 攻击目标僵尸的 ID
 		/// @param special 是否使用副武器进行攻击
 		/// @return 生成的子弹
+		/// @todo 将此函数的目标参数改为 Zombie
 		PVZ::Projectile Shoot(MotionType::MotionType motiontype = MotionType::None, int targetid = -1, bool special = false);
 		/// @deprecated 请改用 PlayBodyReanim()。
 		[[deprecated]] void SetAnimation(LPCSTR animName, PVZEnum::ReanimLoopType animPlayArg, int imagespeed);

--- a/pvzclass/Classes/Plant.cpp
+++ b/pvzclass/Classes/Plant.cpp
@@ -169,7 +169,7 @@ PVZ::Projectile PVZ::Plant::Shoot(MotionType::MotionType motiontype, int targeti
 	__asm__Shoot[3] = Row;
 	if (targetid != -1)
 	{
-		Zombie tmp = Zombie(ID_INDEX(targetid));
+		Zombie tmp = PVZ::GetByID<Zombie>(targetid);
 		SETARG(__asm__Shoot, 5) = tmp.GetBaseAddress();
 	}
 	SETARG(__asm__Shoot, 10) = BaseAddress;

--- a/pvzclass/Enums/MouseType.h
+++ b/pvzclass/Enums/MouseType.h
@@ -23,7 +23,7 @@ namespace MouseType
 		WheelBarrow,
 		TreeFood,
 	};
-	constexpr MouseType CobCannonTarget = Crosshair;
+	inline constexpr MouseType CobCannonTarget = Crosshair;
 
 	extern const char* ToString(MouseType mouset);
 

--- a/pvzclass/Enums/ProjectileType.h
+++ b/pvzclass/Enums/ProjectileType.h
@@ -20,7 +20,7 @@ namespace ProjectileType
 		ZombiePea,
 	};
 
-	constexpr ProjectileType Cactus = Spike;
+	inline constexpr ProjectileType Cactus = Spike;
 
 	extern const char* ToString(ProjectileType projectilet);
 

--- a/pvzclass/PVZ.h
+++ b/pvzclass/PVZ.h
@@ -46,7 +46,7 @@ using std::is_base_of;
 #define ID_INDEX(id) ((id) & 0x0000FFFF)
 #define ID_RANK(id) ((id) & 0xFFFF0000)
 
-constexpr auto INVALID_BASEADDRESS = 0x400000;
+inline constexpr auto INVALID_BASEADDRESS = 0x400000;
 
 /// @brief 包含大部分用于控制 PVZ 内部对象的类和方法。
 /// @note Only version 1.0.0.1051 is fully supported

--- a/pvzclass/include/Flags.hpp
+++ b/pvzclass/include/Flags.hpp
@@ -6,27 +6,27 @@ namespace PVZ
 	typedef unsigned char DamageRangeFlags;
 
 	/// @brief 是否位于地面上（或水面上）。
-	constexpr DamageRangeFlags DRF_GROUND = (1 << 0);
+	inline constexpr DamageRangeFlags DRF_GROUND = (1 << 0);
 	/// @brief 是否飞行。
-	constexpr DamageRangeFlags DRF_FLYING = (1 << 1);
+	inline constexpr DamageRangeFlags DRF_FLYING = (1 << 1);
 	/// @brief 是否潜水。
-	constexpr DamageRangeFlags DRF_SUBMERGED = (1 << 2);
+	inline constexpr DamageRangeFlags DRF_SUBMERGED = (1 << 2);
 	/// @brief 内测版中用于判断是否为僵尸狗。正式版 PVZ 中被废弃。
-	constexpr DamageRangeFlags DRF_DOG = (1 << 3);
+	inline constexpr DamageRangeFlags DRF_DOG = (1 << 3);
 	/// @brief 是否正在落地（或出土）。
-	constexpr DamageRangeFlags DRF_OFF_GROUND = (1 << 4);
+	inline constexpr DamageRangeFlags DRF_OFF_GROUND = (1 << 4);
 	/// @brief 是否考虑已被击杀的僵尸。
-	constexpr DamageRangeFlags DRF_DYING = (1 << 5);
+	inline constexpr DamageRangeFlags DRF_DYING = (1 << 5);
 	/// @brief 是否位于地下。
-	constexpr DamageRangeFlags DRF_UNDERGROUND = (1 << 6);
+	inline constexpr DamageRangeFlags DRF_UNDERGROUND = (1 << 6);
 	/// @brief 是否被魅惑。
-	constexpr DamageRangeFlags DRF_HYPNOTIZED = (1 << 7);
+	inline constexpr DamageRangeFlags DRF_HYPNOTIZED = (1 << 7);
 
 	/// @brief 全体未被魅惑的僵尸。
-	constexpr DamageRangeFlags DRF_ALL = DRF_GROUND | DRF_FLYING
+	inline constexpr DamageRangeFlags DRF_ALL = DRF_GROUND | DRF_FLYING
 		| DRF_SUBMERGED | DRF_DOG | DRF_OFF_GROUND | DRF_DYING | DRF_UNDERGROUND;
 	/// @brief 全体被魅惑的僵尸。
-	constexpr DamageRangeFlags DRF_ALL_HYPNOTIZED = DRF_HYPNOTIZED | DRF_ALL;
+	inline constexpr DamageRangeFlags DRF_ALL_HYPNOTIZED = DRF_HYPNOTIZED | DRF_ALL;
 
 	#pragma endregion
 


### PR DESCRIPTION
- 修复了 `Plant::Shoot()` 未适配 `GetByID()` 的漏洞。
- 将所有 `constexpr` 常量变为内联常量。
- `REG_EUX` 系列宏改为内联常量。