### PR TITLE
WriteArrayUnsafe 等性能优化

### DIFF
--- a/pvzclass/Classes/Animation.cpp
+++ b/pvzclass/Classes/Animation.cpp
@@ -46,10 +46,10 @@ PVZ::Color PVZ::Animation::GetColor()
 
 void PVZ::Animation::SetColor(Color color)
 {
-	Memory::WriteMemory<int>(BaseAddress + 0x48, color.Red);
-	Memory::WriteMemory<int>(BaseAddress + 0x4C, color.Green);
-	Memory::WriteMemory<int>(BaseAddress + 0x50, color.Blue);
-	Memory::WriteMemory<int>(BaseAddress + 0x54, color.Alpha);
+	Memory::WriteMemoryUnsafe<int>(BaseAddress + 0x48, color.Red);
+	Memory::WriteMemoryUnsafe<int>(BaseAddress + 0x4C, color.Green);
+	Memory::WriteMemoryUnsafe<int>(BaseAddress + 0x50, color.Blue);
+	Memory::WriteMemoryUnsafe<int>(BaseAddress + 0x54, color.Alpha);
 }
 
 PVZ::Color PVZ::Animation::GetAdditiveColor()
@@ -64,10 +64,10 @@ PVZ::Color PVZ::Animation::GetAdditiveColor()
 
 void PVZ::Animation::SetAdditiveColor(Color color)
 {
-	Memory::WriteMemory<int>(BaseAddress + 0x6C, color.Red);
-	Memory::WriteMemory<int>(BaseAddress + 0x70, color.Green);
-	Memory::WriteMemory<int>(BaseAddress + 0x74, color.Blue);
-	Memory::WriteMemory<int>(BaseAddress + 0x78, color.Alpha);
+	Memory::WriteMemoryUnsafe<int>(BaseAddress + 0x6C, color.Red);
+	Memory::WriteMemoryUnsafe<int>(BaseAddress + 0x70, color.Green);
+	Memory::WriteMemoryUnsafe<int>(BaseAddress + 0x74, color.Blue);
+	Memory::WriteMemoryUnsafe<int>(BaseAddress + 0x78, color.Alpha);
 }
 
 PVZ::Color PVZ::Animation::GetOverlayColor()
@@ -82,10 +82,10 @@ PVZ::Color PVZ::Animation::GetOverlayColor()
 
 void PVZ::Animation::SetOverlayColor(Color color)
 {
-	Memory::WriteMemory<int>(BaseAddress + 0x80, color.Red);
-	Memory::WriteMemory<int>(BaseAddress + 0x84, color.Green);
-	Memory::WriteMemory<int>(BaseAddress + 0x88, color.Blue);
-	Memory::WriteMemory<int>(BaseAddress + 0x8C, color.Alpha);
+	Memory::WriteMemoryUnsafe<int>(BaseAddress + 0x80, color.Red);
+	Memory::WriteMemoryUnsafe<int>(BaseAddress + 0x84, color.Green);
+	Memory::WriteMemoryUnsafe<int>(BaseAddress + 0x88, color.Blue);
+	Memory::WriteMemoryUnsafe<int>(BaseAddress + 0x8C, color.Alpha);
 }
 
 PVZ::TrackInstance PVZ::Animation::GetTrackInstance(const char* trackName)
@@ -112,7 +112,7 @@ void PVZ::Animation::Die()
 
 void PVZ::Animation::Play(const char* trackName, int blendType, PVZEnum::ReanimLoopType loopType, float rate)
 {
-	PVZ::Memory::WriteArray<const char>(PVZ::Memory::Variable + 100, trackName, std::strlen(trackName) + 1);
+	PVZ::Memory::WriteArrayUnsafe<const char>(PVZ::Memory::Variable + 100, trackName, std::strlen(trackName) + 1);
 	SETARGFLOAT(__asm__Reanimation__Play, 1) = rate;
 	SETARG(__asm__Reanimation__Play, 7) = blendType;
 	SETARG(__asm__Reanimation__Play, 12) = BaseAddress;
@@ -132,7 +132,7 @@ byte __asm__Reanimation__IsAnimPlaying[29]
 
 bool PVZ::Animation::IsAnimPlaying(const char* trackName)
 {
-	PVZ::Memory::WriteArray<const char>(PVZ::Memory::Variable + 100, trackName, std::strlen(trackName) + 1);
+	PVZ::Memory::WriteArrayUnsafe<const char>(PVZ::Memory::Variable + 100, trackName, std::strlen(trackName) + 1);
 	SETARG(__asm__Reanimation__IsAnimPlaying, 1) = PVZ::Memory::Variable + 100;
 	SETARG(__asm__Reanimation__IsAnimPlaying, 6) = BaseAddress;
 	SETARG(__asm__Reanimation__IsAnimPlaying, 24) = PVZ::Memory::Variable;
@@ -152,7 +152,7 @@ bool PVZ::Animation::ShouldTriggerTimedEvent(float thetime)
 
 void PVZ::Animation::AssignRenderGroupToPrefix(const char* trackName, byte RenderGroup)
 {
-	PVZ::Memory::WriteArray<const char>(PVZ::Memory::Variable + 100, trackName, std::strlen(trackName) + 1);
+	PVZ::Memory::WriteArrayUnsafe<const char>(PVZ::Memory::Variable + 100, trackName, std::strlen(trackName) + 1);
 	__asm__Reanimation__AssignGroupToPrefix[1] = RenderGroup;
 	SETARG(__asm__Reanimation__AssignGroupToPrefix, 3) = PVZ::Memory::Variable + 100;
 	SETARG(__asm__Reanimation__AssignGroupToPrefix, 8) = this->BaseAddress;
@@ -162,7 +162,7 @@ void PVZ::Animation::AssignRenderGroupToPrefix(const char* trackName, byte Rende
 AsmBuilder AssignRenderGroupToTrack_builder = AsmBuilder();
 void PVZ::Animation::AssignRenderGroupToTrack(const char* trackName, byte renderGroup)
 {
-	PVZ::Memory::WriteArray<const char>(PVZ::Memory::Variable + 100, trackName, std::strlen(trackName) + 1);
+	PVZ::Memory::WriteArrayUnsafe<const char>(PVZ::Memory::Variable + 100, trackName, std::strlen(trackName) + 1);
 	AssignRenderGroupToTrack_builder.clear()
 		.push(renderGroup)
 		.push_imm32(PVZ::Memory::Variable + 100)
@@ -175,7 +175,7 @@ void PVZ::Animation::AssignRenderGroupToTrack(const char* trackName, byte render
 
 int PVZ::Animation::FindTrackIndex(const char* trackName)
 {
-	PVZ::Memory::WriteArray<const char>(PVZ::Memory::Variable + 100, trackName, std::strlen(trackName) + 1);
+	PVZ::Memory::WriteArrayUnsafe<const char>(PVZ::Memory::Variable + 100, trackName, std::strlen(trackName) + 1);
 	SETARG(__asm__Reanimation__FindTrackIndex, 1) = BaseAddress;
 	SETARG(__asm__Reanimation__FindTrackIndex, 6) = PVZ::Memory::Variable + 100;
 	SETARG(__asm__Reanimation__FindTrackIndex, 24) = PVZ::Memory::Variable;
@@ -192,7 +192,7 @@ byte __asm__Reanimation_SetFramesForLayer[]
 
 void PVZ::Animation::SetFramesForLayer(const char* theTrackName)
 {
-	PVZ::Memory::WriteArray<const char>(PVZ::Memory::Variable + 100, theTrackName, std::strlen(theTrackName) + 1);
+	PVZ::Memory::WriteArrayUnsafe<const char>(PVZ::Memory::Variable + 100, theTrackName, std::strlen(theTrackName) + 1);
 	SETARG(__asm__Reanimation_SetFramesForLayer, 1) = PVZ::Memory::Variable + 100;
 	SETARG(__asm__Reanimation_SetFramesForLayer, 6) = this->BaseAddress;
 	PVZ::Memory::Execute(STRING(__asm__Reanimation_SetFramesForLayer));
@@ -209,7 +209,7 @@ byte __asm__Reanimation_SetImageOverride[]
 
 void PVZ::Animation::SetImageOverride(const char* theTrackName, Image theImage)
 {
-	PVZ::Memory::WriteArray<const char>(PVZ::Memory::Variable + 100, theTrackName, std::strlen(theTrackName) + 1);
+	PVZ::Memory::WriteArrayUnsafe<const char>(PVZ::Memory::Variable + 100, theTrackName, std::strlen(theTrackName) + 1);
 	SETARG(__asm__Reanimation_SetImageOverride, 1) = theImage.GetBaseAddress();
 	SETARG(__asm__Reanimation_SetImageOverride, 6) = PVZ::Memory::Variable + 100;
 	SETARG(__asm__Reanimation_SetImageOverride, 11) = this->GetBaseAddress();

--- a/pvzclass/Memory.hpp
+++ b/pvzclass/Memory.hpp
@@ -124,13 +124,32 @@ namespace PVZ
 		/// @param address 数据的内存地址
 		/// @param result 待写入数据的指针
 		/// @param length 数组的长度（按字节计）
-		/// @return 读取是否成功
+		/// @return 写入是否成功
 		template <class T>
 		inline static BOOL WriteArray(DWORD address, T* value, size_t length)
 		{
 			if (localExecute)
 			{
 				AllAccess(address);
+				memcpy((void*)address, value, length);
+				return true;
+			}
+			else
+			{
+				return WriteProcessMemory(hProcess, (LPVOID)address, value, length, NULL);
+			}
+		};
+		/// @brief 将一连串数据写入 PVZ 程序指定地址。在 localExecute 为 true 时，忽略权限设置。
+		/// @tparam T 数据类型
+		/// @param address 数据的内存地址
+		/// @param result 待写入数据的指针
+		/// @param length 数组的长度（按字节计）
+		/// @return 写入是否成功
+		template <class T>
+		inline static BOOL WriteArrayUnsafe(DWORD address, T* value, size_t length)
+		{
+			if (localExecute)
+			{
 				memcpy((void*)address, value, length);
 				return true;
 			}

--- a/pvzclass/include/Events/DLLEvent.h
+++ b/pvzclass/include/Events/DLLEvent.h
@@ -22,18 +22,20 @@ using std::endl;
 class DLLEvent
 {
 public:
+	virtual ~DLLEvent();
 	/// @brief 取消该事件产生的效应。
 	void end();
 
 protected:
 	int rawlen, hookAddress;
 	/// @brief 将指定代码段注入。
+	/// @attention 不要反复调用此函数，这会导致内存泄露。
 	/// @param code 代码段
 	/// @param len 代码段长度
 	void start(BYTE* code, int len);
 
 private:
-	BYTE* rawCode;
+	BYTE* rawCode = nullptr;
 	static int newAddress;
 };
 

--- a/pvzclass/src/Events/DLLEvent.cpp
+++ b/pvzclass/src/Events/DLLEvent.cpp
@@ -12,13 +12,13 @@ void DLLEvent::start(BYTE* code, int newlen)
 	for (int i = 5; i < rawlen; i++) PVZ::Memory::WriteMemory<BYTE>(hookAddress + i, NOP);
 
 	BYTE jmpback[] = { JMPFAR(hookAddress - (newAddress + newlen + 7)) };
-	PVZ::Memory::WriteMemory<BYTE>(newAddress, PUSHAD);
-	PVZ::Memory::WriteArray<BYTE>(newAddress + 1, code, newlen);
-	PVZ::Memory::WriteMemory<BYTE>(newAddress + newlen + 1, POPAD);
-	PVZ::Memory::WriteArray<BYTE>(newAddress + newlen + 2, rawCode, rawlen);
-	PVZ::Memory::WriteArray<BYTE>(newAddress + newlen + rawlen + 2, jmpback, 5);
+	PVZ::Memory::WriteMemoryUnsafe<BYTE>(newAddress, PUSHAD);
+	PVZ::Memory::WriteArrayUnsafe<BYTE>(newAddress + 1, code, newlen);
+	PVZ::Memory::WriteMemoryUnsafe<BYTE>(newAddress + newlen + 1, POPAD);
+	PVZ::Memory::WriteArrayUnsafe<BYTE>(newAddress + newlen + 2, rawCode, rawlen);
 	if (rawCode[0] == 0xE8 || rawCode[0] == 0xE9)
 		PVZ::Memory::WriteMemoryUnsafe<uint32_t>(newAddress + newlen + 3, SETARG(rawCode, 1) + hookAddress - newAddress - newlen - 2);
+	PVZ::Memory::WriteArrayUnsafe<BYTE>(newAddress + newlen + rawlen + 2, jmpback, 5);
 	newAddress += newlen + rawlen + 0x10;
 }
 

--- a/pvzclass/src/Events/DLLEvent.cpp
+++ b/pvzclass/src/Events/DLLEvent.cpp
@@ -22,6 +22,12 @@ void DLLEvent::start(BYTE* code, int newlen)
 	newAddress += newlen + rawlen + 0x10;
 }
 
+DLLEvent::~DLLEvent()
+{
+	if (rawCode != nullptr)
+		delete[](rawCode);
+}
+
 void DLLEvent::end()
 {
 	PVZ::Memory::WriteArray<BYTE>(hookAddress, rawCode, rawlen);

--- a/pvzclass/src/Events/DLLEvent.cpp
+++ b/pvzclass/src/Events/DLLEvent.cpp
@@ -7,17 +7,18 @@ void DLLEvent::start(BYTE* code, int newlen)
 	if (newAddress == 0) newAddress = PVZ::Memory::AllocMemory(16, 0);
 	rawCode = new BYTE[rawlen];
 	PVZ::Memory::ReadArray<BYTE>(hookAddress, rawCode, rawlen);
-	if (rawCode[0] == 0xE8 || rawCode[0] == 0xE9)
-		SETARG(rawCode, 1) = SETARG(rawCode, 1) + hookAddress - newAddress - newlen - 2;
 	BYTE jmpto[] = { JMPFAR(newAddress - (hookAddress + 5)) };
 	PVZ::Memory::WriteArray<BYTE>(hookAddress, jmpto, 5);
 	for (int i = 5; i < rawlen; i++) PVZ::Memory::WriteMemory<BYTE>(hookAddress + i, NOP);
+
 	BYTE jmpback[] = { JMPFAR(hookAddress - (newAddress + newlen + 7)) };
 	PVZ::Memory::WriteMemory<BYTE>(newAddress, PUSHAD);
 	PVZ::Memory::WriteArray<BYTE>(newAddress + 1, code, newlen);
 	PVZ::Memory::WriteMemory<BYTE>(newAddress + newlen + 1, POPAD);
 	PVZ::Memory::WriteArray<BYTE>(newAddress + newlen + 2, rawCode, rawlen);
 	PVZ::Memory::WriteArray<BYTE>(newAddress + newlen + rawlen + 2, jmpback, 5);
+	if (rawCode[0] == 0xE8 || rawCode[0] == 0xE9)
+		PVZ::Memory::WriteMemoryUnsafe<uint32_t>(newAddress + newlen + 3, SETARG(rawCode, 1) + hookAddress - newAddress - newlen - 2);
 	newAddress += newlen + rawlen + 0x10;
 }
 


### PR DESCRIPTION
- 新增 `Memory::WriteArrayUnsafe()`，用于省略 `AllAccess()`。
- `Animation` 中大部分可使用 Unsafe 版本函数的地点均换用 Unsafe 版本。
- `DLLEvent` 添加内存泄露保护，并使用 Unsafe 版本函数。
- 修复部分 `DLLEvent` 在调用 `end()` 后出现不正常现象的漏洞。