### PR TITLE
修复 `ProcessOpener` 漏洞，其他改动

### DIFF
--- a/pvzclass/Memory.hpp
+++ b/pvzclass/Memory.hpp
@@ -34,6 +34,7 @@ namespace PVZ
 		/// @brief 主线程 ID
 		static DWORD mainThreadId;
 		/// @brief 主窗口句柄
+		/// @deprecated 即将被移除
 		static HWND mainwindowhandle;
 		/// @brief 如果为 true，则不会等待PVZ进程，立即执行远程代码
 		/// @note 在 localExecute 为 true 时无效。

--- a/pvzclass/PVZ.h
+++ b/pvzclass/PVZ.h
@@ -558,7 +558,7 @@ namespace PVZ
 		AttachmentID GetAttachmentID();
 		Attachment GetAttachment();
 	};
-	// 鼠标对象(控制层面的鼠标)
+	/// @deprecated 该类将在未来被重命名为 WidgetManager
 	class Mouse : public BaseClass
 	{
 	public:

--- a/pvzclass/PVZ.h
+++ b/pvzclass/PVZ.h
@@ -567,9 +567,11 @@ namespace PVZ
 		INT_PROPERTY(X, __get_X, __set_X, 0xE0);
 		INT_PROPERTY(Y, __get_Y, __set_Y, 0xE4);
 		T_READONLY_PROPERTY(MouseClickState::MouseClickState, ClickState, __get_ClickState, 0xE8);
-		void WMClick(short x, short y);
+		/// @deprecated 即将被移除
+		[[deprecated]] void WMClick(short x, short y);
 		void GameClick(int x, int y);
-		void MoveTo(int x, int y);
+		/// @deprecated 即将被移除
+		[[deprecated]] void MoveTo(int x, int y);
 	};
 	class GardenPlant : public BaseClass
 	{

--- a/pvzclass/src/ProcessOpener.cpp
+++ b/pvzclass/src/ProcessOpener.cpp
@@ -1,6 +1,5 @@
 ﻿#include "ProcessOpener.h"
 #include <TLHELP32.H>
-#include <direct.h>
 LPCWSTR ProcessOpener::ProcessName = TEXT("PlantsVsZombies.exe");
 LPCWSTR ProcessOpener::WindowTitle = TEXT("Plants vs. Zombies");
 LPCWSTR ProcessOpener::Directory = TEXT(".");
@@ -31,12 +30,17 @@ DWORD ProcessOpener::OpenByWindowTitle(LPCWSTR processName)
 	return pid;
 }
 
+WCHAR FilePathBuf[MAX_PATH + 1];
 DWORD ProcessOpener::OpenByFilePath(LPCWSTR directory, LPCWSTR executeableName)
 {
-	int _ = _wchdir(directory);
 	STARTUPINFO startupInfo = { 0 };
 	PROCESS_INFORMATION processInformation = { 0 };
-	BOOL ret = CreateProcess(executeableName, NULL, NULL, NULL, FALSE, NULL, NULL, NULL, &startupInfo, &processInformation);
+
+	wcscpy_s(FilePathBuf, MAX_PATH, directory);
+	wcscat_s(FilePathBuf, MAX_PATH, L"\\");
+	wcscat_s(FilePathBuf, MAX_PATH, executeableName);
+
+	BOOL ret = CreateProcess(FilePathBuf, NULL, NULL, NULL, FALSE, NULL, NULL, directory, &startupInfo, &processInformation);
 	if (ret)
 	{
 		CloseHandle(processInformation.hProcess);


### PR DESCRIPTION
- 修复 `ProcessOpener::OpenByFilePath()` 会修改工作目录的漏洞。
- 为 `Mouse` 类及其部分函数标注为 `deprecated`。