### PR TITLE
修复 SetMemSize 漏洞，废弃内容移除

### DIFF
--- a/docs/3.0迁移指南.md
+++ b/docs/3.0迁移指南.md
@@ -78,3 +78,13 @@
 - 移除了 `PlantEffectType` 及相关函数。
   - 影响等级：极低
   - 首次发布版本：TBD
+- 移除了 `Zombie::AccessoriesType` 系列函数。
+  - 影响等级：低
+  - 首次发布版本：TBD
+  - 迁移建议：
+    - 改用 `Helm` 系列属性和 `Shield` 系列属性。
+- 移除了 `Zombie::SetHealth` 和 `Zombie::GetHealth`。
+  - 影响等级：低
+  - 首次发布版本：TBD
+  - 迁移建议：
+    - 改用 `Body` 系列属性。

--- a/pvzclass/Classes/GameObject.hpp
+++ b/pvzclass/Classes/GameObject.hpp
@@ -89,21 +89,6 @@ namespace PVZ
 		/// @param NewCount 调整后僵尸上限数
 		static void SetMemSize(int NewSize, int NewCount);
 
-		/// @deprecated
-		struct AccessoriesType1
-		{
-			HelmType::HelmType Type;
-			int Hp;
-			int MaxHp;
-		};
-		/// @deprecated
-		struct AccessoriesType2
-		{
-			ShieldType::ShieldType Type;
-			int Hp;
-			int MaxHp;
-		};
-
 		/// @brief 僵尸类型
 		T_PROPERTY(ZombieType::ZombieType, Type, __get_Type, __set_Type, 0x24);
 		/// @brief 僵尸状态
@@ -375,19 +360,6 @@ namespace PVZ
 		void ShowDoorArms(bool shown = true);
 		/// @brief 根据盾的类型设置相应动画轨道的绘制分组。
 		void AttachShield();
-
-		/// @deprecated
-		void GetBodyHp(int* hp, int* maxhp);
-		/// @deprecated
-		void SetBodyHp(int hp, int maxhp);
-		/// @deprecated
-		AccessoriesType1 GetAccessoriesType1();
-		/// @deprecated
-		void SetAccessoriesType1(AccessoriesType1 acctype1);
-		/// @deprecated
-		AccessoriesType2 GetAccessoriesType2();
-		/// @deprecated
-		void SetAccessoriesType2(AccessoriesType2 acctype2);
 	};
 	/// @brief 植物
 	class Plant : public GameObject

--- a/pvzclass/Classes/Projectile.cpp
+++ b/pvzclass/Classes/Projectile.cpp
@@ -13,7 +13,7 @@ void PVZ::Projectile::SetMemSize(int NewSize, int NewCount)
 		return;
 	MemSize = NewSize;
 
-	Memory::WriteMemory<int>(0x407D04, NewSize * NewCount);
+	Memory::WriteMemory<int>(0x407D05, NewSize * NewCount);
 
 	byte __asm__Mem1[] = { ADD_EAX_DWORD(NewSize) };
 	byte __asm__Mem2[] = { ADD_EUX_DWORD(REG_ESI, NewSize) };

--- a/pvzclass/Classes/Zombie.cpp
+++ b/pvzclass/Classes/Zombie.cpp
@@ -120,39 +120,6 @@ void PVZ::Zombie::SetAttackCollision(CollisionBox* collbox)
 	Memory::WriteMemoryUnsafe<int>(BaseAddress + 0xA8, collbox->Height);
 }
 
-PVZ::Zombie::AccessoriesType1 PVZ::Zombie::GetAccessoriesType1()
-{
-	AccessoriesType1 acctype1;
-	acctype1.Type = Memory::ReadMemory<HelmType::HelmType>(BaseAddress + 0xC4);
-	acctype1.Hp = Memory::ReadMemory<int>(BaseAddress + 0xD0);
-	acctype1.MaxHp = Memory::ReadMemory<int>(BaseAddress + 0xD4);
-	return acctype1;
-}
-
-void PVZ::Zombie::SetAccessoriesType1(AccessoriesType1 acctype1)
-{
-	Memory::WriteMemoryUnsafe<HelmType::HelmType>(BaseAddress + 0xC4, acctype1.Type);
-	Memory::WriteMemoryUnsafe<int>(BaseAddress + 0xD0, acctype1.Hp);
-	Memory::WriteMemoryUnsafe<int>(BaseAddress + 0xD4, acctype1.MaxHp);
-}
-
-PVZ::Zombie::AccessoriesType2 PVZ::Zombie::GetAccessoriesType2()
-{
-	AccessoriesType2 acctype2;
-	acctype2.Type = Memory::ReadMemory<ShieldType::ShieldType>(BaseAddress + 0xD8);
-	acctype2.Hp = Memory::ReadMemory<int>(BaseAddress + 0xDC);
-	acctype2.MaxHp = Memory::ReadMemory<int>(BaseAddress + 0xE0);
-	return acctype2;
-}
-
-void PVZ::Zombie::SetAccessoriesType2(AccessoriesType2 acctype2)
-{
-	Memory::WriteMemoryUnsafe<ShieldType::ShieldType>(BaseAddress + 0xD8, acctype2.Type);
-	Memory::WriteMemoryUnsafe<int>(BaseAddress + 0xDC, acctype2.Hp);
-	Memory::WriteMemoryUnsafe<int>(BaseAddress + 0xE0, acctype2.MaxHp);
-
-}
-
 AsmBuilder ShowDoorArms_builder = AsmBuilder();
 void PVZ::Zombie::ShowDoorArms(bool shown)
 {
@@ -172,18 +139,6 @@ void PVZ::Zombie::AttachShield()
 		.invoke(0x533000)
 		.ret()
 	);
-}
-
-void PVZ::Zombie::GetBodyHp(int* hp, int* maxhp)
-{
-	*hp = Memory::ReadMemory<int>(BaseAddress + 0xC8);
-	*maxhp = Memory::ReadMemory<int>(BaseAddress + 0xCC);
-}
-
-void PVZ::Zombie::SetBodyHp(int hp, int maxhp)
-{
-	Memory::WriteMemoryUnsafe<int>(BaseAddress + 0xC8, hp);
-	Memory::WriteMemoryUnsafe<int>(BaseAddress + 0xCC, maxhp);
 }
 
 PVZ::Animation PVZ::Zombie::GetAnimation()
@@ -387,18 +342,22 @@ void PVZ::Zombie::PlayZombieReanimation(DWORD animAddress, PVZEnum::ReanimLoopTy
 
 void PVZ::Zombie::EquipBucket(int shield)
 {
-	if (this->GetAccessoriesType1().Type)
+	if (this->HelmType)
 		return;
 	this->GetAnimation().AssignRenderGroupToPrefix("anim_bucket", 0);
-	this->SetAccessoriesType1({ HelmType::Bucket, shield, shield });
+	this->HelmType = HelmType::Bucket;
+	this->HelmHealth = shield;
+	this->HelmMaxHealth = shield;
 }
 
 void PVZ::Zombie::EquipCone(int shield)
 {
-	if (this->GetAccessoriesType1().Type)
+	if (this->HelmType)
 		return;
 	this->GetAnimation().AssignRenderGroupToPrefix("anim_cone", 0);
-	this->SetAccessoriesType1({ HelmType::RoadCone, shield, shield });
+	this->HelmType = HelmType::RoadCone;
+	this->HelmHealth = shield;
+	this->HelmMaxHealth = shield;
 }
 
 void PVZ::Zombie::ReanimShowPrefix(const char* TrackName, int renderGroup)

--- a/pvzclass/include/Events/ZombieTakeDmgEvent.h
+++ b/pvzclass/include/Events/ZombieTakeDmgEvent.h
@@ -1,13 +1,9 @@
 #pragma once
 #include "DLLEvent.h"
 
-// 僵尸受伤事件
-// 参数：触发事件的僵尸，伤害类型，伤害数值
-// 返回值：更新后的伤害值
-// 多个事件之间伤害会串联修改，例如基础伤害20
-// 第一个监听器翻倍至40，第二个事件监听到的伤害数值就是40
-// 如不作其它修改，僵尸最后会受到40点伤害
-/// @deprecated
+/// @brief 僵尸受伤事件
+/// @param 触发事件的僵尸，伤害类型，伤害数值
+/// @return 更新后的伤害值
 class ZombieHitEvent : public DLLEvent
 {
 public:


### PR DESCRIPTION
- 修复 `Projectile::SetMemSize()` 会导致崩溃的漏洞。
- 移除了 `Zombie` 类的部分废弃成员。