### PR TITLE
漏洞修复

### DIFF
--- a/pvzclass/Classes/Projectile.cpp
+++ b/pvzclass/Classes/Projectile.cpp
@@ -43,7 +43,7 @@ void PVZ::Projectile::SetMemSize(int NewSize, int NewCount)
 
 	Memory::WriteArray<byte>(0X481DAE, STRING(__asm__Mem5));
 	Memory::WriteArray<byte>(0X481DC8, STRING(__asm__Mem1));
-	Memory::WriteArray<byte>(0X48244C, STRING(__asm__Mem4));
+	Memory::WriteArray<byte>(0X48244C, STRING(__asm__Mem6));
 }
 
 byte __asm__Projectile_CheckForCollision[]

--- a/pvzclass/include/Extensions.h
+++ b/pvzclass/include/Extensions.h
@@ -260,10 +260,12 @@ inline void DisableIceLevelFailSound(BOOLEAN b = true)
 
 /// @brief 关闭关卡内大部分内容的绘制。\n
 ///		建议仅在调试和测试环境下调用此函数。
+/// @note 该函数不会禁用帧频更新
 /// @param b 是否开启此功能
 inline void DisableBoardDraw(BOOLEAN b = true)
 {
-	MEMMOD_BYTE(0x41AD23, 129, 133);
+	MEMMOD_BYTE(0x41AE33, 0x0F, 0xE8);
+	MEMMOD_INT(0x41AE34, 0x441F, 0xFFFFBA48);
 }
 
 /// @brief 阻止新生成的粒子系统产生粒子效果。\n


### PR DESCRIPTION
- 修复 `PVZ::Projectile::SetMemSize()` 导致存读档崩溃的漏洞。
- 修复 `DisableBoardDraw()` 会关闭帧频结算，导致部分情况下 Board 初始化无法开始游戏的漏洞。