### PR TITLE
拼写错误修复 & 文件重归类

### DIFF
--- a/pvzclass/Classes/Board.hpp
+++ b/pvzclass/Classes/Board.hpp
@@ -264,7 +264,7 @@ namespace PVZ
 		/// @tparam T 成员值的类型，必须为 Projectile 或它的派生类。
 		/// @return 装有全体 Projectile （或者其派生类）对象的 std::vector
 		template<typename T = Projectile, typename = enable_if_t<is_base_of<Projectile, T>::value>>
-		std::vector<T> GetAllProjectile()
+		std::vector<T> GetAllProjectiles()
 		{
 			return __prototype_GetAll<T, 0x0C8, 0x0CC, 0x50>();
 		}

--- a/pvzclass/Enums/ZombieState.cpp
+++ b/pvzclass/Enums/ZombieState.cpp
@@ -1,4 +1,4 @@
-﻿#include "ZombieState.h"
+#include "ZombieState.h"
 
 const char* ZombieState::ToString(ZombieState state)
 {
@@ -50,8 +50,8 @@ const char* ZombieState::ToString(ZombieState state)
 		return "POGO_JUMP_ACROSS";
 	case NEWSPAPER_WALKING:
 		return "NEWSPAPER_WALKING";
-	case NEWSPAPER_DESTORYED:
-		return "NEWSPAPER_DESTORYED";
+	case NEWSPAPER_DESTROYED:
+		return "NEWSPAPER_DESTROYED";
 	case NEWSPAPER_RUNNING:
 		return "NEWSPAPER_RUNNING";
 	case DIGGER_DIG:

--- a/pvzclass/Enums/ZombieState.h
+++ b/pvzclass/Enums/ZombieState.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <string>
 
@@ -29,7 +29,7 @@ namespace ZombieState
 		POGO_IDLE_BEFORE_TARGET = 0x15,
 		POGO_JUMP_ACROSS = 0x1B,
 		NEWSPAPER_WALKING = 0x1D,
-		NEWSPAPER_DESTORYED = 0x1E,
+		NEWSPAPER_DESTROYED = 0x1E,
 		NEWSPAPER_RUNNING = 0x1F,
 		DIGGER_DIG = 0x20,
 		DIGGER_DRILL = 0x21,

--- a/pvzclass/PVZ.h
+++ b/pvzclass/PVZ.h
@@ -171,7 +171,7 @@ namespace PVZ
 		Rect Intersection(const Rect& rect) const;
 		/// @brief 判断矩形是否非空
 		/// @return 矩形非空
-		inline bool IsVaild()
+		inline bool IsValid()
 		{
 			return this->X | this->Y | this->Width | this->Height;
 		}

--- a/pvzclass/pvzclass.vcxproj.filters
+++ b/pvzclass/pvzclass.vcxproj.filters
@@ -360,9 +360,6 @@
     <ClCompile Include="Enums\AnimationType.cpp">
       <Filter>源文件</Filter>
     </ClCompile>
-    <ClCompile Include="include\Events\ProjectileDrawTransEvent.hpp">
-      <Filter>源文件</Filter>
-    </ClCompile>
     <ClCompile Include="src\Effects\EffectSystem.cpp">
       <Filter>源文件</Filter>
     </ClCompile>
@@ -374,6 +371,9 @@
     </ClCompile>
     <ClCompile Include="src\Global.cpp">
       <Filter>源文件</Filter>
+    </ClCompile>
+    <ClCompile Include="include\Events\ProjectileDrawTransEvent.hpp">
+      <Filter>头文件\Events\Projectile</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- 将 `PVZ::Board` 下的函数 `GetAllProjectile` 重命名为 `GetAllProjectiles`
- 将 `PVZ::Rect` 下的函数 `IsVaild` 重命名为 `IsValid`
- 将 `ZombieState::ZombieState` 下的枚举值 `NEWSPAPER_DESTORYED` 重命名为 `NEWSPAPER_DESTROYED`
- 将 [ProjectileDrawTransEvent.hpp](https://github.com/PVZClassAcademy/pvzclass/tree/Refurbishment/pvzclass/include/Events/ProjectileDrawTransEvent.hpp) 在项目配置中重归类为 头文件